### PR TITLE
Website settings fetch changed

### DIFF
--- a/models/WebsiteSetting/Dao.php
+++ b/models/WebsiteSetting/Dao.php
@@ -62,7 +62,7 @@ class Dao extends Model\Dao\PhpArrayTable
             if ($name && $row['name'] != $name) {
                 $return = false;
             }
-            if ($row['siteId'] && $siteId && $row['siteId'] != $siteId) {
+            if ($row['siteId'] && $row['siteId'] != $siteId) {
                 $return = false;
             }
 


### PR DESCRIPTION
For multidomain environments website settings are not selected correctly. 
In my case a custom website setting "contactFormEmailRecipient" is set for main site and a sub site. The`$data` array holds two results and for the sub site `$data[0]` is taken. This is not correct in my case. With this fix, `$data` holds only one result and everything is fine.


Bug fix: 6.9

